### PR TITLE
docs(nyuremote): rewrite tool launching for the current server, add a Git/GitHub setup page

### DIFF
--- a/docs/support/amd/lauching.md
+++ b/docs/support/amd/lauching.md
@@ -33,10 +33,9 @@ In Windows, you can run both the Vitis IDE and Vivado IDE from the **Start menu*
 To use any command line tool, you will need to set the path.  In the instructions below, I have assumed that users working locally on Linux and Windows are on version 2025.1, while users on the NYU remote machine are on the newer 2026.1.  I will test the demos and labs to make sure everything works on both versions as the semester progresses.
 
 {: .important }
-> On the NYU servers this step is **not optional**.  Logging in puts an older
-> 2023.2 Vivado and Vitis HLS on your path automatically, so skipping the
-> settings command silently gives you the wrong tool version.  See
-> [Tool Version Problem](../nyuremote/launching.md#tool-version-problem).
+> **On the NYU servers, do not use the `settings64` commands below.**  There you load
+> the tools with a single `module load` instead — see
+> [Launching Vitis and Vivado on the NYU server](../nyuremote/launching.md).
 
 For a Vivado command line tool:
 

--- a/docs/support/nyuremote/github.md
+++ b/docs/support/nyuremote/github.md
@@ -1,0 +1,224 @@
+---
+title: Setting up Git and GitHub
+parent: NYU Remote Server
+nav_order: 4
+has_children: False
+---
+# Setting up Git and GitHub on the NYU Server
+
+You need Git working on the server for two reasons:
+
+1. To **clone the course repository**, `hwdesign`, so you have the labs and demos.
+2. To **push your own work** — your project repository, and anything you fork.
+
+You do **not** need to clone `waveflow`. It installs directly from GitHub as a package;
+see [Installing the Python packages](../repo/package.md). Clone it only if you intend to
+modify the framework itself.
+
+Git is already installed on the servers (version 2.52 at the time of writing), so there
+is nothing to install for step 1. Authentication is the part that needs setting up.
+
+---
+
+## 1. Tell Git who you are
+
+Git stamps every commit with a name and email. Set them once:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "your_netid@nyu.edu"
+```
+
+Use the same email as your GitHub account, or GitHub will not connect your commits to
+your profile.
+
+## 2. Clone the course repository
+
+Cloning a public repository needs no authentication at all, so you can do this
+immediately:
+
+```bash
+cd ~
+git clone https://github.com/sdrangan/hwdesign.git
+```
+
+Then follow [Using Python](./python.md) to build the environment and install the
+packages.
+
+{: .note }
+> This is enough to *do the labs*. The rest of this page is about pushing your own work
+> back to GitHub, which you will need for your project.
+
+---
+
+## 3. Authenticate so you can push
+
+Pushing requires proving who you are. Cloning over HTTPS as above leaves Git prompting
+for a username and password on every push, and GitHub stopped accepting account
+passwords years ago — so this step is not optional once you start writing.
+
+**Use the GitHub CLI (`gh`).** It handles authentication for both `gh` *and* `git`, so
+you set up credentials once rather than twice, and it needs no manually created access
+token.
+
+### Install `gh`
+
+`gh` is not installed on the EDA servers, and you cannot install system software. Install
+it into your home directory instead — the same approach used for `uv` in
+[Using Python](./python.md):
+
+```bash
+mkdir -p ~/.local/bin
+cd /tmp
+curl -fsSL https://github.com/cli/cli/releases/download/v2.97.0/gh_2.97.0_linux_amd64.tar.gz -o gh.tgz
+tar xzf gh.tgz
+cp gh_2.97.0_linux_amd64/bin/gh ~/.local/bin/
+chmod +x ~/.local/bin/gh
+```
+
+{: .note }
+> Version 2.97.0 is pinned above because the download filename contains the version
+> number. Any recent release works — check
+> [the releases page](https://github.com/cli/cli/releases/latest) for a newer one and
+> substitute the number in all three places.
+
+If you already followed [Using Python](./python.md), `~/.local/bin` is on your path
+already. Check:
+
+```bash
+gh --version
+```
+
+If that reports `Command not found`, add the directory to your path as described in
+[Using Python](./python.md#if-your-shell-is-tcsh).
+
+### Log in
+
+```bash
+gh auth login
+```
+
+Answer the prompts: **GitHub.com** → **HTTPS** → **Yes** (authenticate Git with your
+GitHub credentials) → **Login with a web browser**.
+
+`gh` then prints an eight-character code and a URL. Open that URL on your **laptop**
+(not on the server — there is no browser there), paste the code, and approve. The
+terminal completes on its own.
+
+This is the reason to prefer the browser flow: it works fine over SSH, and you never
+create or copy a token by hand.
+
+### Point Git at the same credentials
+
+```bash
+gh auth setup-git
+```
+
+This configures Git to ask `gh` for credentials, so `git push` and `git pull` just work
+from then on — no prompts, no token pasting.
+
+### Check it
+
+```bash
+gh auth status
+```
+
+You should see `Logged in to github.com account <your-username>`.
+
+---
+
+## 4. Working with your own repositories
+
+With the above done, everything behaves normally:
+
+```bash
+gh repo create my-project --private --clone     # create and clone in one step
+cd my-project
+# ... work ...
+git add -A
+git commit -m "First version"
+git push
+```
+
+To work on an existing repository of yours:
+
+```bash
+gh repo clone <your-username>/<your-repo>
+```
+
+`gh` is also how you open pull requests and read issues without leaving the terminal:
+
+```bash
+gh pr create --fill
+gh pr status
+gh issue list
+```
+
+---
+
+## 5. If you use Claude or another AI coding agent
+
+Agents cannot open a browser, so they rely on credentials already stored on disk. The
+setup above is exactly what they need: `gh auth login` writes `~/.config/gh/hosts.yml`,
+and `gh auth setup-git` makes Git use it. An agent running in your account can then
+clone, commit, push, and open pull requests on your behalf with no further configuration.
+
+Two things are worth knowing:
+
+**`~/.local/bin` may not be on the agent's path.** Agents often start a shell that does
+not read your shell startup files the same way your terminal does. If an agent reports
+that `gh` is not found, tell it to use the full path `~/.local/bin/gh`.
+
+**An exported token overrides the stored login.** If you set `GH_TOKEN` in your
+environment, `gh` uses it and *refuses to store credentials* — you will see:
+
+```
+The value of the GH_TOKEN environment variable is being used for authentication.
+To have GitHub CLI store credentials instead, first clear the value from the environment.
+```
+
+Nothing is saved, so an agent (whose shell does not have your variable) stays
+unauthenticated. If you have already created a token and want to keep using it, store it
+explicitly with the variable stripped from `gh`'s own environment:
+
+```bash
+echo $GH_TOKEN | env -u GH_TOKEN gh auth login --with-token
+```
+
+Otherwise just use `gh auth login` as above and do not set `GH_TOKEN` at all — one
+credential in one place is simpler to reason about and to revoke.
+
+---
+
+## Security on a shared machine
+
+These servers are shared, and authentication leaves a long-lived credential in your home
+directory (`~/.config/gh/hosts.yml`, and `~/.git-credentials` if you use a token).
+
+- **Check your home directory is private.** It should be, by default:
+
+  ```bash
+  ls -ld ~
+  ```
+
+  The permissions should begin `drwx------`. If they do not, fix it with
+  `chmod 700 ~`.
+
+- **Never commit secrets.** API keys, tokens, and passwords do not belong in a
+  repository — including a private one. Once pushed, a secret is in the history even
+  after you delete the file.
+
+- **Log out when you are done with the machine** if you would rather not leave a
+  credential behind:
+
+  ```bash
+  gh auth logout
+  ```
+
+- **Revoke rather than repair** if you ever think a credential leaked: delete it at
+  <https://github.com/settings/tokens> (or under *Settings → Applications* for the CLI's
+  authorization) and log in again.
+
+---
+
+Go to [using Python](./python.md)

--- a/docs/support/nyuremote/launching.md
+++ b/docs/support/nyuremote/launching.md
@@ -4,114 +4,67 @@ parent: NYU Remote Server
 nav_order: 3
 has_children: False
 ---
-# Launching Vitis and Vivado within the Remote server
+# Launching Vitis and Vivado within the Remote Server
 
-## NYU Server Version
+## Tool version
 
-At the time of writing, the NYU EDA servers have been upgraded to version 2026.1 of the Vitis and Vivado tools.  We will ensure that the labs and demos work for this version, even though some of the material was developed for a slightly earlier 2025.1 version.
+The NYU EDA servers run version **2026.1** of Vitis and Vivado. Some of the course
+material was developed against the slightly earlier 2025.1, and we will keep the labs
+and demos working on both.
 
-## Environment Variable Problem
+## Loading the tools
 
-The NYU EDA servers are configured to set paths to software for different classes.  At the time of writing, there appears to be a mis-configuration of an environment variable for the Cadence software that is not needed for this class.  
-
-The problem is in the file, `tcshrc_cadence_local`.  This file mis-sets an environment variable `LD_PRELOAD`.  `LD_PRELOAD` forces a shared library into *every* program you run, so a setting meant for Cadence also reaches Vitis, Vivado, and Python — where it can produce loader or missing-symbol errors that look nothing like a Cadence problem.
-
-For this class, unset the variable:
+The tools are not on your path when you log in. Load them with a single command:
 
 ```bash
-unsetenv LD_PRELOAD
+module load /home/shared/modules/xilinx
 ```
 
-That fixes the current shell only.  To avoid retyping it at every login, add the
-same line to the **end** of your own `~/.tcshrc`.  Your account ships with a
-`~/.tcshrc` that sources the EDA setup files first and applies your own settings
-afterwards, so anything you add at the bottom takes precedence:
+Then launch either tool by name:
 
 ```bash
-# Sources of all application files  (installed by NYU IT)
-source ~/tcshrc_cadence_local
-source ~/tcshrc_mentor_local
-source ~/tcshrc_synopsys_local
-source ~/tcshrc_xilinx_local
-echo 'EDA tools: environment files sourced'
-
-# Your own settings
-setenv PATH "$HOME/.local/bin:$PATH"
-unsetenv PYTHONPATH
-unsetenv LD_PRELOAD
+vitis      # Vitis IDE
+vivado     # Vivado IDE
 ```
 
-The `PATH` and `PYTHONPATH` lines come from [setting up Python](./python.md); the
-`LD_PRELOAD` line is the one to add here.  Because they sit below the `source`
-commands, they override whatever the EDA files set.
+That is the whole procedure. The `module load` also sets the license server, so nothing
+else needs configuring.
 
-Then open a fresh login and confirm it is gone:
+{: .note }
+> Run `module load` once per login session — it affects only the terminal you type it
+> in. If you open a second terminal, run it again there.
+
+## Checking that it worked
 
 ```bash
-echo $LD_PRELOAD
+vitis -version
+vivado -version
 ```
 
-This should print nothing.
+Both should report **2026.1**. If instead you get `Command not found`, you have not run
+the `module load` in that terminal.
 
-{: .warning }
-> Do **not** delete the line from `~/tcshrc_cadence_local` itself.  NYU IT
-> installs those files into your home directory and may replace them when
-> accounts are re-provisioned — silently undoing your change and leaving you to
-> rediscover the problem.  You may also need Cadence for another course.
-> Unsetting the variable at the end of your own `~/.tcshrc` has exactly the same
-> effect, survives IT updates, and is a single line to remove if you ever want
-> the original behaviour back.
+## Loading the tools automatically
 
-
-## Tool Version Problem
-
-Your account automatically sources `~/tcshrc_xilinx_local` at login, and that file
-puts the **old 2023.2** tools on your path:
+If you would rather not type the command at every login, add it to the end of your
+`~/.tcshrc` (the default shell on these servers is `tcsh`):
 
 ```bash
-setenv XILINX /eda/xilinx/
-set path=( $path $XILINX/Vivado/2023.2/bin $XILINX/Vitis_HLS/2023.2/bin $XILINX/DocNav )
+module load /home/shared/modules/xilinx
 ```
 
-So if you log in and simply type `vivado`, you get version **2023.2**, not the
-2026.1 version this class uses — and nothing warns you.  The same applies to
-`vitis_hls`, which is the 2023.2 HLS tool; in 2026.1 the HLS flow is
-`vitis-run --mode hls` instead.
+New logins will then have the tools available immediately. This is safe unless you are
+also taking a course that needs a different Xilinx version, in which case it is better
+to load it per session.
 
-This matters because Xilinx project files are generally **not** backward
-compatible.  Using the old tools by accident usually does not fail immediately;
-it fails later, with confusing errors about a project built by a newer version.
+## The GUIs need a graphical connection
 
-You must therefore run the settings command for 2026.1 in each session before
-using the tools:
-
-```bash
-source /eda/xilinx/2026.1/Vivado/settings64.csh    # for Vivado
-source /eda/xilinx/2026.1/Vitis/settings64.csh     # for Vitis
-```
-
-{: .important }
-> Always confirm which version you actually have before starting work:
->
-> ```bash
-> vivado -version
-> vitis --version
-> ```
->
-> If either reports 2023.2, you are on the old tools and have not sourced the
-> settings file.  (Note the inconsistent flags: `vivado` takes one dash,
-> `vitis` takes two.)
-
-If you would rather not type this at every login, you can add the `source` lines
-to the end of your own `~/.tcshrc`, below the other settings described above.
-Only do this if you are not also taking a course that needs the 2023.2 tools,
-since it changes the default for every session.
-
-## Launching Vitis and Vivado
-
-Once you have SSH-ed or connected via Fast-X into one of the NYU EDA servers, 
-you can follow the [launching instructions](../amd/lauching.md) to start either the Vitis or Vivado tools.
+`vitis` and `vivado` with no arguments open full graphical applications. Over a plain
+SSH connection they have nowhere to draw and will fail or hang. Connect with
+[Fast-X](./fastx.md) first, or use the command-line tools instead — see
+[Launching Vitis and Vivado](../amd/lauching.md) for what each tool does and for the
+batch-mode commands such as `vitis-run --mode hls` and `xsim`.
 
 ---
 
-Go to [running python remotely](./python.md)
+Go to [setting up Git and GitHub](./github.md)

--- a/docs/support/nyuremote/python.md
+++ b/docs/support/nyuremote/python.md
@@ -1,7 +1,7 @@
 ---
 title: Using Python
 parent: NYU Remote Server
-nav_order: 4
+nav_order: 5
 has_children: False
 ---
 # Using Python
@@ -217,10 +217,9 @@ environment is not activated.  If it raises an error mentioning `pysilicon`,
 that is unmigrated course material rather than a broken install — see the note
 at the end of [Installing the Python packages](../repo/package.md).
 
-If instead you see a shared-library or missing-symbol error before Python even
-starts, that is the `LD_PRELOAD` misconfiguration on the EDA servers, not a
-problem with your environment — see
-[Environment Variable Problem](./launching.md#environment-variable-problem).
+(An earlier build of the EDA servers set a stray `LD_PRELOAD` that produced
+shared-library errors before Python even started. Those configuration files have
+since been removed, so this should no longer occur.)
 
 ## 5. Running Python
 


### PR DESCRIPTION
## Launching Vitis and Vivado — rewritten

The page documented two problems with an earlier build of the EDA servers that no longer exist. Verified on `ecs03` before removing them:

- no `tcshrc_*` files in the home directory
- `LD_PRELOAD` unset
- `~/.tcshrc` empty
- the 2023.2 trees gone from `/eda/xilinx`

Both sections are deleted rather than softened — instructions for a machine that no longer exists cost a student more time than no instructions at all.

What replaces them is the whole procedure:

```bash
module load /home/shared/modules/xilinx
vitis      # Vitis IDE
vivado     # Vivado IDE
```

Confirmed in **tcsh** (the students' login shell, not the author's): both resolve under `/eda/xilinx/2026.1`, and the module sets `XILINXD_LICENSE_FILE`, so nothing else needs configuring.

Three additions beyond the bare commands, each a thing a student otherwise discovers the hard way:

- `module load` affects only the terminal it is typed in
- both tools open GUIs that fail over plain SSH — Fast-X, or the batch tools
- how to load it automatically, with the caveat about other courses on other versions

Also dropped the old warning that `vitis` needs two dashes for `--version`: on 2026.1 it accepts both spellings, so the warning is now itself wrong.

## Setting up Git and GitHub — new page

Students clone `hwdesign` and install `waveflow` as a package, so cloning needs no authentication — but pushing their project work does, and nothing covered that.

Leads with `gh auth login` (browser device flow) plus `gh auth setup-git` rather than a hand-made access token:

- no token to create or paste
- works headless over SSH — code on the server, approval on a laptop
- one credential then serves both `git` and `gh`

Includes a section for students running AI coding agents, encoding two failures hit while setting this up for real on `ecs03`: `~/.local/bin` is not necessarily on an agent's `PATH`, and an exported `GH_TOKEN` makes `gh` **refuse** to store credentials — quoted verbatim, since the message is otherwise hard to search for.

The `gh` install snippet is tested end to end in tcsh. The obvious `releases/latest/download/gh_linux_amd64.tar.gz` URL **404s** (asset names embed the version), so the version is pinned with a note on where to find newer ones.

Closes with shared-machine security: check `~` is `drwx------`, never commit secrets, `gh auth logout`, and revoke rather than repair.

## Knock-on fixes

Deleting those sections broke two inbound anchor links, both repaired here:

- `python.md` referenced `#environment-variable-problem` for an error that can no longer occur
- `amd/lauching.md` referenced `#tool-version-problem` while telling NYU users the `settings64` step was mandatory — now actively wrong, since `module load` replaces it there

`python.md` moves to `nav_order: 5` so the chain reads ssh → fastx → launching → github → python; cloning has to precede the virtual environment, so GitHub setup belongs before Python. Every relative link in the touched files was checked to resolve, along with the `#if-your-shell-is-tcsh` anchor.

## Not done

`docs/support/amd/lauching.md` is misspelled (missing the `n`) and five pages link to it. Left alone as out of scope for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
