### PR TITLE
SSH: host key changes after the server rebuild, and which folder to open

### DIFF
--- a/docs/support/nyuremote/ssh.md
+++ b/docs/support/nyuremote/ssh.md
@@ -74,7 +74,44 @@ If you use VS Code, the **Remote – SSH** extension provides a full development
 5. Choose your user SSH config file when prompted
    - Windows: `C:\Users\<username>\.ssh\config`
    - macOS/Linux: `~/.ssh/config`
-6. Connect to the host and select a folder (typically your home directory).
+6. Connect to the host. Wait for the status bar at the bottom left to turn green
+   and read `SSH: ecs03.poly.edu` — until it does, you are still browsing your
+   own machine.
+7. **File → Open Folder**, and choose the **repository** directory, normally
+   `/home/<netid>/hwdesign`.
+
+{: .note }
+> **Open the repository folder, not your home directory.** VS Code keys a great
+> deal off the folder you open. The Python extension looks for `.venv` relative
+> to it, so opening your home directory means the environment you built in
+> [Using Python](./python.md) is never found, and every `import waveflow` is
+> marked as an error even though the code runs fine. Opening your home directory
+> also makes VS Code watch and search everything beneath it — including the
+> several-hundred-megabyte `~/.vscode-server` tree and the EDA tool directories
+> — which makes the window noticeably sluggish, since home directories on these
+> servers are network-mounted.
+
+### Course developers
+
+If you are following the [developer setup](../repo/developer.md), you may want
+both the `waveflow` and `hwdesign` folders open at once. You do **not** need two
+VS Code windows, and you should not open your home directory to get both.
+Instead, use a **multi-root workspace**:
+
+1. Open `~/hwdesign` as above.
+2. **File → Add Folder to Workspace…** and choose `~/waveflow`.
+3. **File → Save Workspace As…** and save it — for example as
+   `~/hwdesign.code-workspace`.
+
+Both repositories now appear as top-level folders in a single Explorer, with
+search, `Ctrl+P`, and Source Control spanning the pair. Each folder keeps its own
+settings, and the editable install means an edit in `waveflow` takes effect in
+`hwdesign` immediately. Reopen the pair later from **File → Open Workspace from
+File…**, or from the **Recent** list.
+
+This is only useful with the editable install described on that page. Students
+install `waveflow` as a package and never clone it, so a single `~/hwdesign`
+folder is all they need.
 
 ### What you get
 
@@ -85,6 +122,52 @@ If you use VS Code, the **Remote – SSH** extension provides a full development
 - The ability to edit files directly on the remote server with IntelliSense, syntax highlighting, etc.
 
 This is the best option for macOS users and an excellent alternative for Windows users who prefer VS Code over MobaXterm.
+
+---
+
+## If SSH warns that the host key has changed
+
+When connecting you may be stopped by a warning like this, and the connection
+refused:
+
+```
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@    WARNING: REMOTE HOST IDENTIFICATION HAS CHANGED!      @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+...
+Offending ECDSA key in C:\Users\<username>/.ssh/known_hosts:6
+Host key verification failed.
+```
+
+Your SSH client remembers an identifying key for every server you have
+connected to, and refuses to continue when the key it is offered does not match
+the one it recorded. The EDA servers were reinstalled during the recent tools
+upgrade, and a reinstalled machine generates new keys — so if you connected to
+these servers in a previous semester, you will see this.
+
+Remove the stored key and reconnect:
+
+```bash
+ssh-keygen -R ecs03.poly.edu
+```
+
+Substitute whichever host you are connecting to. The command rewrites
+`known_hosts` and leaves a backup in `known_hosts.old`; it works on Windows,
+macOS, and Linux. Reconnect and answer `yes` when asked to accept the new key.
+
+Prefer this to editing `known_hosts` by hand — a single host can occupy several
+lines, and deleting the wrong one is easy.
+
+{: .note }
+> If VS Code Remote-SSH fails to connect with only a generic "could not
+> establish connection" message, try connecting from a terminal first. VS Code
+> hits the same host key check but reports it far less clearly.
+
+{: .warning }
+> This warning also has a genuine security meaning, and a routine server rebuild
+> looks exactly like an attempted interception. Clearing the key is the right
+> move here because we know these servers were reinstalled. On a machine you have
+> no such explanation for, do not clear the key — contact whoever administers it.
 
 ---
 


### PR DESCRIPTION
Two additions to the NYU remote SSH page, both from problems the rebuilt servers now cause.

**Host key changes.** The EDA servers were reinstalled during the tools upgrade, so anyone who connected in a previous semester now meets `REMOTE HOST IDENTIFICATION HAS CHANGED` and simply cannot get in. Documents `ssh-keygen -R <host>` rather than hand-editing `known_hosts`, since a single host can occupy several lines and deleting the wrong one is easy.

Two things that save time: VS Code Remote-SSH hits the same check but reports it as a generic "could not establish connection", so trying from a terminal first is the faster diagnosis. And the security caveat is kept — a routine rebuild and an attempted interception look identical, so clearing the key is right *here* only because we know these machines were reinstalled.

**Which folder to open.** VS Code keys a lot off the opened folder: the Python extension looks for `.venv` relative to it, so opening the home directory means the environment is never found and every `import waveflow` is flagged even though the code runs. It also makes VS Code watch and search the several-hundred-megabyte `~/.vscode-server` tree and the EDA directories, over a network-mounted home. For developers who want both repos open, a multi-root workspace rather than two windows.

---

Carved out of a stale local working tree. The rest of that WIP — an `LD_PRELOAD` workaround and a "Loading the tools" section — was superseded by #7, which correctly removed `LD_PRELOAD` after NYU IT fixed the servers. Only the `ssh.md` half is genuinely new, and `ssh.md` was untouched upstream, so this applies cleanly.